### PR TITLE
[CBP-6830]: Upgrade to go 1.24.1

### DIFF
--- a/.cloudbees/workflows/workflow.yml
+++ b/.cloudbees/workflows/workflow.yml
@@ -19,7 +19,7 @@ jobs:
         uses: https://github.com/cloudbees-io/checkout@v1
 
       - name: Self Test
-        uses: docker://golang:1.22.5
+        uses: docker://golang:1.24.1
         run: |
           make verify
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.19 as certs
 
 RUN apk add -U --no-cache ca-certificates
 
-FROM golang:1.22.5-alpine3.19 AS build
+FROM golang:1.24.1-alpine3.21 AS build
 
 WORKDIR /work
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudbees-io/configure-oci-credentials
 
-go 1.22.5
+go 1.24.1
 
 require (
 	github.com/spf13/cobra v1.7.0


### PR DESCRIPTION
This is to fix security vulnerabilities in [CVE-2024-34156](https://nvd.nist.gov/vuln/detail/CVE-2024-34156) and [CVE-2024-34158](https://nvd.nist.gov/vuln/detail/CVE-2024-34158).